### PR TITLE
Display color diff of JSON representations of documents that differ between collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 # Python virtual environment.
 /venv
 /.venv
+
+# Compiled/bytecode files.
+*.pyc

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ mongo-diff --help
 We currently only have a smattering of doctests in this codebase. You can run them via:
 
 ```shell
-poetry run python -m doctest ./mongo_diff/**/*.py
+poetry run python -m doctest ./mongo_diff/mongo_diff.py
 ```
 
 We may eventually populate the `tests/` directory with a more exhaustive test suite,

--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ While editing the tool's source code, you can run the tool as you normally would
 mongo-diff --help
 ```
 
+### Run tests
+
+We currently only have a smattering of doctests in this codebase. You can run them via:
+
+```shell
+poetry run python -m doctest ./mongo_diff/**/*.py
+```
+
+We may eventually populate the `tests/` directory with a more exhaustive test suite,
+using [pytest](https://docs.pytest.org/en/stable/) and [mongomock](https://pypi.org/project/mongomock/).
+
 ### Build package
 
 #### Update package version

--- a/README.md
+++ b/README.md
@@ -62,10 +62,9 @@ At the time of this writing, the tool's `--help` snippet is:
  databases (even across servers).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --include-id    --no-include-id      Includes the `_id` field when comparing │
-│                                      documents.                              │
-│                                      [default: no-include-id]                │
-│ --help                               Show this message and exit.             │
+│ --include-oid,--include-id          Includes the `_id` field when comparing  │
+│                                     documents.                               │
+│ --help                              Show this message and exit.              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Collection A ───────────────────────────────────────────────────────────────╮
 │ *  --mongo-uri-a                    TEXT  Connection string for accessing    │

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -203,11 +203,13 @@ def diff_collections(
                         document_a,
                         json_options=json_util.CANONICAL_JSON_OPTIONS,
                         indent=2,
+                        sort_keys=True,
                     )
                     b_json = json_util.dumps(
                         document_b,
                         json_options=json_util.CANONICAL_JSON_OPTIONS,
                         indent=2,
+                        sort_keys=True,
                     )
                     diff_lines = unified_diff(
                         a_json.splitlines(),

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -199,14 +199,16 @@ def diff_collections(
 
                     # Display a colorized diff of the two documents' canonical JSON representations.
                     # Docs: https://pymongo.readthedocs.io/en/stable/api/bson/json_util.html
+                    document_a_without_ignored_fields = document_a if include_id else {k: v for k, v in document_a.items() if k != "_id"}
+                    document_b_without_ignored_fields = document_b if include_id else {k: v for k, v in document_b.items() if k != "_id"}
                     a_json = json_util.dumps(
-                        document_a,
+                        document_a_without_ignored_fields,
                         json_options=json_util.CANONICAL_JSON_OPTIONS,
                         indent=2,
                         sort_keys=True,
                     )
                     b_json = json_util.dumps(
-                        document_b,
+                        document_b_without_ignored_fields,
                         json_options=json_util.CANONICAL_JSON_OPTIONS,
                         indent=2,
                         sort_keys=True,
@@ -214,15 +216,15 @@ def diff_collections(
                     diff_lines = unified_diff(
                         a_json.splitlines(),
                         b_json.splitlines(),
-                        fromfile=f"Collection A: {identifier_value_a}",
-                        tofile=f"Collection B: {identifier_value_b}",
+                        fromfile=f"Collection A: {identifier_field_name_a}={identifier_value_a}",
+                        tofile=f"Collection B: {identifier_field_name_b}={identifier_value_b}",
                         lineterm="",
                     )
                     for line in diff_lines:
                         if line.startswith("+"):
-                            console.print(f"[green]{line}[/green]")
+                            console.print(line, style="green", highlight=False)
                         elif line.startswith("-"):
-                            console.print(f"[red]{line}[/red]")
+                            console.print(line, style="red", highlight=False)
                         else:
                             console.print(line, highlight=False)
 

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -398,7 +398,17 @@ def diff_collections(
                 )
 
             # Check whether a document having the same identifier value exists in collection A.
-            document_a = collection_a.find_one({identifier_field_name_a: identifier_value_b})
+            #
+            # Note: If the identifier value from document B was `None`, we use a special filter
+            #       (when checking collection A) to disambiguate between documents in which the
+            #       identifier field contains `None` and documents in which the identifier field
+            #       does not exist at all. MongoDB does not distinguish between those two cases when
+            #       we use a basic filter like `{field_name: None}`.
+            #
+            filter_a: dict = {identifier_field_name_a: identifier_value_b}
+            if identifier_value_b is None:
+                filter_a = make_pymongo_filter_for_field_having_value_null(identifier_field_name_a)
+            document_a = collection_a.find_one(filter=filter_a)
 
             # If such a document exists in collection B, compare it to the one from collection A.
             if document_a is None:

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -1,5 +1,4 @@
 from difflib import unified_diff
-from pathlib import Path
 from typing import Iterator, Optional
 
 import dictdiffer
@@ -88,7 +87,7 @@ class Comparator():
         label_b: str,
     ) -> Iterator[str]:
         r"""
-        Returns an iterator that yiels the lines of a Git-like diff of the documents'
+        Returns an iterator that yields the lines of a Git-like diff of the documents'
         canonical JSON representations.
 
         Reference: https://pymongo.readthedocs.io/en/stable/api/bson/json_util.html

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -1,5 +1,6 @@
 from difflib import unified_diff
-from typing import Optional
+from pathlib import Path
+from typing import Iterator, Optional
 
 import dictdiffer
 import typer
@@ -66,6 +67,53 @@ class Result:
                                        condition=self.num_documents_that_differ_across_collections > 0,
                                        color="red"))
         return table
+
+
+class Comparator():
+    @staticmethod
+    def compare_documents(document_a: dict, document_b: dict) -> bool:
+        r"""
+        Returns `True` if the documents have the same fields and values as one another; otherwise `False`.
+        """
+
+        differences_generator = dictdiffer.diff(document_a, document_b)
+        differences: list[tuple] = list(differences_generator)
+        return len(differences) == 0
+
+    @staticmethod
+    def generate_diff(
+        document_a: dict,
+        document_b: dict,
+        label_a: str,
+        label_b: str,
+    ) -> Iterator[str]:
+        r"""
+        Returns an iterator that yiels the lines of a Git-like diff of the documents'
+        canonical JSON representations.
+
+        Reference: https://pymongo.readthedocs.io/en/stable/api/bson/json_util.html
+        """
+
+        a_json = json_util.dumps(
+            document_a,
+            json_options=json_util.CANONICAL_JSON_OPTIONS,
+            indent=2,
+            sort_keys=True,
+        )
+        b_json = json_util.dumps(
+            document_b,
+            json_options=json_util.CANONICAL_JSON_OPTIONS,
+            indent=2,
+            sort_keys=True,
+        )
+        diff_lines = unified_diff(
+            a_json.splitlines(),
+            b_json.splitlines(),
+            fromfile=label_a,
+            tofile=label_b,
+            lineterm="",
+        )
+        return diff_lines
 
 
 @app.command("diff-collections")
@@ -175,6 +223,7 @@ def diff_collections(
     report = Result(num_documents_in_collection_a, num_documents_in_collection_b)
 
     # Set up the progress bar functionality.
+    console.print()
     with Progress(console=console) as progress:
         # Compare the collections, using collection A as the reference.
         #
@@ -200,36 +249,23 @@ def diff_collections(
 
             # If such a document exists in collection B, compare it to the one from collection A.
             if document_b is not None:
-                differences_generator = dictdiffer.diff(document_a, document_b)
-                differences = list(differences_generator)
-                if len(differences) > 0:
+                comparator = Comparator()
+                are_the_same = comparator.compare_documents(
+                    document_a=document_a,
+                    document_b=document_b,
+                )
+
+                if not are_the_same:
                     report.num_documents_that_differ_across_collections += 1
                     identifier_value_b = document_b[identifier_field_name_b]
-                    console.print(f"Documents differ between collections: "
-                                  f"{identifier_field_name_a}={identifier_value_a},"
-                                  f"{identifier_field_name_b}={identifier_value_b}. "
-                                  f"Differences: {differences}")
+                    console.print("Document differs between collections:")
 
                     # Display a colorized diff of the two documents' canonical JSON representations.
-                    # Docs: https://pymongo.readthedocs.io/en/stable/api/bson/json_util.html
-                    a_json = json_util.dumps(
-                        document_a,
-                        json_options=json_util.CANONICAL_JSON_OPTIONS,
-                        indent=2,
-                        sort_keys=True,
-                    )
-                    b_json = json_util.dumps(
-                        document_b,
-                        json_options=json_util.CANONICAL_JSON_OPTIONS,
-                        indent=2,
-                        sort_keys=True,
-                    )
-                    diff_lines = unified_diff(
-                        a_json.splitlines(),
-                        b_json.splitlines(),
-                        fromfile=f"Collection A: {identifier_field_name_a}={identifier_value_a}",
-                        tofile=f"Collection B: {identifier_field_name_b}={identifier_value_b}",
-                        lineterm="",
+                    diff_lines = comparator.generate_diff(
+                        document_a=document_a,
+                        document_b=document_b,
+                        label_a=f"Collection A: {identifier_field_name_a}={identifier_value_a!r}",
+                        label_b=f"Collection B: {identifier_field_name_b}={identifier_value_b!r}",
                     )
                     for line in diff_lines:
                         if line.startswith("+"):
@@ -238,11 +274,15 @@ def diff_collections(
                             console.print(line, style="red", highlight=False)
                         else:
                             console.print(line, highlight=False)
+                    console.print()
 
             else:
                 report.num_documents_in_collection_a_only += 1
-                console.print(f"Document exists in collection A only: "
-                              f"{identifier_field_name_a}={document_a[identifier_field_name_a]}")
+                console.print(
+                    f"Document exists in collection A only: "
+                    f"[red]{identifier_field_name_a}={identifier_value_a!r}[/red]",
+                    highlight=False,
+                )
 
             # Advance the progress bar by 1.
             progress.update(task_a, advance=1)
@@ -274,8 +314,11 @@ def diff_collections(
             # If such a document exists in collection B, compare it to the one from collection A.
             if document_a is None:
                 report.num_documents_in_collection_b_only += 1
-                console.print(f"Document exists in collection B only: "
-                              f"{identifier_field_name_b}={document_b[identifier_field_name_b]}")
+                console.print(
+                    f"Document exists in collection B only: "
+                    f"[green]{identifier_field_name_b}={identifier_value_b!r}[/green]",
+                    highlight=False,
+                )
 
             # Advance the progress bar by 1.
             progress.update(task_b, advance=1)

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -86,8 +86,16 @@ class Comparator():
 
         fields_to_ignore = {"_id"} if ignore_oid else set()
         differences_generator = dictdiffer.diff(document_a, document_b, ignore=fields_to_ignore)
-        differences: list[tuple] = list(differences_generator)
-        return len(differences) == 0
+
+        # Check whether the generator (which is an iterator) yields any differences.
+        documents_are_same = False
+        try:
+            # Note: If this statement causes a `StopIteration` to be raised, it means the generator
+            #       does not have any differences to yield (i.e. the documents match one another).
+            _ = next(differences_generator)
+        except StopIteration:
+            documents_are_same = True
+        return documents_are_same
 
     @staticmethod
     def generate_diff(

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -75,6 +75,13 @@ class Comparator():
         r"""
         Returns `True` if the documents have the same fields and values as one another;
         otherwise `False`. Considers the `_id` field unless you opt out via `ignore_oid`.
+
+        >>> Comparator.compare_documents({"a": 1}, {"a": 1})
+        True
+        >>> Comparator.compare_documents({"_id": 1, "a": 1}, {"_id": 2, "a": 1})
+        False
+        >>> Comparator.compare_documents({"_id": 1, "a": 1}, {"_id": 2, "a": 1}, ignore_oid=True)
+        True
         """
 
         fields_to_ignore = {"_id"} if ignore_oid else set()
@@ -95,6 +102,48 @@ class Comparator():
         JSON representations. Considers the `_id` field unless you opt out via `ignore_oid`.
 
         Reference: https://pymongo.readthedocs.io/en/stable/api/bson/json_util.html
+
+        >>> document_a = dict(_id=1, id="123", name="adam")
+        >>> document_b = dict(_id=2, id="123", name="betty")
+        >>> document_c = dict(_id=1, id="123", name="betty")
+        >>> for line in list(Comparator.generate_diff(document_a, document_b, "left", "right")):
+        ...     print(line)
+        --- left
+        +++ right
+        @@ -1,7 +1,7 @@
+         {
+           "_id": {
+        -    "$numberInt": "1"
+        +    "$numberInt": "2"
+           },
+           "id": "123",
+        -  "name": "adam"
+        +  "name": "betty"
+         }
+        >>> for line in list(Comparator.generate_diff(document_a, document_b, "left", "right", ignore_oid=True)):
+        ...     print(line)
+        --- left
+        +++ right
+        @@ -1,4 +1,4 @@
+         {
+           "id": "123",
+        -  "name": "adam"
+        +  "name": "betty"
+         }
+        >>> for line in list(Comparator.generate_diff(document_b, document_c, "left", "right")):
+        ...     print(line)
+        --- left
+        +++ right
+        @@ -1,6 +1,6 @@
+         {
+           "_id": {
+        -    "$numberInt": "2"
+        +    "$numberInt": "1"
+           },
+           "id": "123",
+           "name": "betty"
+        >>> list(Comparator.generate_diff(document_b, document_c, "left", "right", ignore_oid=True))
+        []
         """
 
         candidate_a = document_a.copy()
@@ -128,12 +177,15 @@ class Comparator():
 def make_pymongo_filter_for_field_having_value_null(field_name: str) -> dict:
     r"""
     Returns a pymongo filter for documents in which the specified field exists and contains `null`.
-    
+
     This helper function is useful because MongoDB interprets the filter `{"field_name": None}` as
     matching both (a) documents in which the specified field contains `null`, and (b) documents in
     which the specified field does not exist. This helper function disambiguates between the two.
 
     Reference: https://www.mongodb.com/docs/manual/tutorial/query-for-null-fields/
+
+    >>> make_pymongo_filter_for_field_having_value_null("id")
+    {'$and': [{'id': {'$exists': True}}, {'id': None}]}
     """
     return {
         "$and": [

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -1,4 +1,5 @@
 from difflib import unified_diff
+from typing import Optional
 
 import dictdiffer
 import typer
@@ -36,7 +37,7 @@ class Result:
         r"""Surrounds the raw string with Rich color tags if the condition is true."""
         return f"[{color}]{raw_string}[/{color}]" if condition else raw_string
 
-    def get_summary_table(self, title: str | None = "Result") -> Table:
+    def get_summary_table(self, title: Optional[str] = "Result") -> Table:
         r"""
         Returns a Rich Table summarizing the result.
 
@@ -90,26 +91,26 @@ def diff_collections(
                  "to use to identify a corresponding document in collection B.",
             rich_help_panel="Collection A",
         )] = "id",
-        mongo_uri_b: Annotated[str, typer.Option(
+        mongo_uri_b: Annotated[Optional[str], typer.Option(
             envvar="MONGO_URI_B",
             help="Connection string for accessing the MongoDB server containing collection B "
                  "(if different from that specified for collection A).",
             show_default=False,
             rich_help_panel="Collection B",
         )] = None,
-        database_name_b: Annotated[str, typer.Option(
+        database_name_b: Annotated[Optional[str], typer.Option(
             help="Name of the database containing collection B "
                  "(if different from that specified for collection A).",
             show_default=False,
             rich_help_panel="Collection B",
         )] = None,
-        collection_name_b: Annotated[str, typer.Option(
+        collection_name_b: Annotated[Optional[str], typer.Option(
             help="Name of collection B "
                  "(if different from that specified for collection A).",
             show_default=False,
             rich_help_panel="Collection B",
         )] = None,
-        identifier_field_name_b: Annotated[str, typer.Option(
+        identifier_field_name_b: Annotated[Optional[str], typer.Option(
             help="Name of the field of each document in collection B "
                  "to use to identify a corresponding document in collection A "
                  "(if different from that specified for collection A).",
@@ -160,6 +161,10 @@ def diff_collections(
             collection = database[collection_name]
             collections.append(collection)
 
+    # Define a MongoDB query projection based upon whether the user wants us to consider the `_id`
+    # field when comparing documents or not.
+    projection = {"_id": 1 if include_id else  0}
+
     # Make more intuitive aliases for the collections.
     collection_a = collections[0]
     collection_b = collections[1]
@@ -179,15 +184,23 @@ def diff_collections(
         #
         task_a = progress.add_task("Comparing collections, using collection A as reference",
                                    total=num_documents_in_collection_a)
-        for document_a in collection_a.find():
+        for document_a in collection_a.find({}, projection):
+
+            # Get the identifier value from the document from collection A.
+            if identifier_field_name_a in document_a:
+                identifier_value_a = document_a[identifier_field_name_a]
+            else:
+                raise ValueError(
+                    f"Document from collection A lacks identifier field: '{identifier_field_name_a}'. "
+                    f"Document: {document_a}"
+                )
+
             # Check whether a document having the same identifier value exists in collection B.
-            identifier_value_a = document_a[identifier_field_name_a]
-            document_b = collection_b.find_one({identifier_field_name_b: identifier_value_a})
+            document_b = collection_b.find_one({identifier_field_name_b: identifier_value_a}, projection)
 
             # If such a document exists in collection B, compare it to the one from collection A.
             if document_b is not None:
-                fields_to_ignore = ["_id"] if not include_id else None
-                differences_generator = dictdiffer.diff(document_a, document_b, ignore=fields_to_ignore)
+                differences_generator = dictdiffer.diff(document_a, document_b)
                 differences = list(differences_generator)
                 if len(differences) > 0:
                     report.num_documents_that_differ_across_collections += 1
@@ -199,16 +212,14 @@ def diff_collections(
 
                     # Display a colorized diff of the two documents' canonical JSON representations.
                     # Docs: https://pymongo.readthedocs.io/en/stable/api/bson/json_util.html
-                    document_a_without_ignored_fields = document_a if include_id else {k: v for k, v in document_a.items() if k != "_id"}
-                    document_b_without_ignored_fields = document_b if include_id else {k: v for k, v in document_b.items() if k != "_id"}
                     a_json = json_util.dumps(
-                        document_a_without_ignored_fields,
+                        document_a,
                         json_options=json_util.CANONICAL_JSON_OPTIONS,
                         indent=2,
                         sort_keys=True,
                     )
                     b_json = json_util.dumps(
-                        document_b_without_ignored_fields,
+                        document_b,
                         json_options=json_util.CANONICAL_JSON_OPTIONS,
                         indent=2,
                         sort_keys=True,
@@ -247,8 +258,17 @@ def diff_collections(
         task_b = progress.add_task("Comparing collections, using collection B as reference",
                                    total=num_documents_in_collection_b)
         for document_b in collection_b.find():
+
+            # Get the identifier value from the document from collection B.
+            if identifier_field_name_b in document_b:
+                identifier_value_b = document_b[identifier_field_name_b]
+            else:
+                raise ValueError(
+                    f"Document from collection B lacks identifier field: {identifier_field_name_b}. "
+                    f"Document: {document_b}"
+                )
+
             # Check whether a document having the same identifier value exists in collection A.
-            identifier_value_b = document_b[identifier_field_name_b]
             document_a = collection_a.find_one({identifier_field_name_a: identifier_value_b})
 
             # If such a document exists in collection B, compare it to the one from collection A.

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -278,11 +278,11 @@ def diff_collections(
                     )
                     for line in diff_lines:
                         if line.startswith("+"):
-                            console.print(line, style="green", highlight=False)
+                            console.print(line, style="green", highlight=False, markup=False)
                         elif line.startswith("-"):
-                            console.print(line, style="red", highlight=False)
+                            console.print(line, style="red", highlight=False, markup=False)
                         else:
-                            console.print(line, highlight=False)
+                            console.print(line, highlight=False, markup=False)
                     console.print()
 
             else:

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -7,6 +7,7 @@ from typing_extensions import Annotated
 from pymongo import MongoClient, timeout
 from bson import json_util
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table, Column
 from rich.progress import Progress
 from rich import box
@@ -288,7 +289,7 @@ def diff_collections(
                 report.num_documents_in_collection_a_only += 1
                 console.print(
                     f"Document exists in collection A only: "
-                    f"[red]{identifier_field_name_a}={identifier_value_a!r}[/red]",
+                    f"[red]{escape(identifier_field_name_a)}={escape(repr(identifier_value_a))}[/red]",
                     highlight=False,
                 )
 
@@ -324,7 +325,7 @@ def diff_collections(
                 report.num_documents_in_collection_b_only += 1
                 console.print(
                     f"Document exists in collection B only: "
-                    f"[green]{identifier_field_name_b}={identifier_value_b!r}[/green]",
+                    f"[green]{escape(identifier_field_name_b)}={escape(repr(identifier_value_b))}[/green]",
                     highlight=False,
                 )
 

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -1,7 +1,10 @@
+from difflib import unified_diff
+
 import dictdiffer
 import typer
 from typing_extensions import Annotated
 from pymongo import MongoClient, timeout
+from bson import json_util
 from rich.console import Console
 from rich.table import Table, Column
 from rich.progress import Progress
@@ -188,10 +191,39 @@ def diff_collections(
                 differences = list(differences_generator)
                 if len(differences) > 0:
                     report.num_documents_that_differ_across_collections += 1
+                    identifier_value_b = document_b[identifier_field_name_b]
                     console.print(f"Documents differ between collections: "
                                   f"{identifier_field_name_a}={identifier_value_a},"
-                                  f"{identifier_field_name_b}={document_b[identifier_field_name_b]}. "
+                                  f"{identifier_field_name_b}={identifier_value_b}. "
                                   f"Differences: {differences}")
+
+                    # Display a colorized diff of the two documents' canonical JSON representations.
+                    # Docs: https://pymongo.readthedocs.io/en/stable/api/bson/json_util.html
+                    a_json = json_util.dumps(
+                        document_a,
+                        json_options=json_util.CANONICAL_JSON_OPTIONS,
+                        indent=2,
+                    )
+                    b_json = json_util.dumps(
+                        document_b,
+                        json_options=json_util.CANONICAL_JSON_OPTIONS,
+                        indent=2,
+                    )
+                    diff_lines = unified_diff(
+                        a_json.splitlines(),
+                        b_json.splitlines(),
+                        fromfile=f"Collection A: {identifier_value_a}",
+                        tofile=f"Collection B: {identifier_value_b}",
+                        lineterm="",
+                    )
+                    for line in diff_lines:
+                        if line.startswith("+"):
+                            console.print(f"[green]{line}[/green]")
+                        elif line.startswith("-"):
+                            console.print(f"[red]{line}[/red]")
+                        else:
+                            console.print(line, highlight=False)
+
             else:
                 report.num_documents_in_collection_a_only += 1
                 console.print(f"Document exists in collection A only: "

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -125,6 +125,24 @@ class Comparator():
         return diff_lines
 
 
+def make_pymongo_filter_for_field_having_value_null(field_name: str) -> dict:
+    r"""
+    Returns a pymongo filter for documents in which the specified field exists and contains `null`.
+    
+    This helper function is useful because MongoDB interprets the filter `{"field_name": None}` as
+    matching both (a) documents in which the specified field contains `null`, and (b) documents in
+    which the specified field does not exist. This helper function disambiguates between the two.
+
+    Reference: https://www.mongodb.com/docs/manual/tutorial/query-for-null-fields/
+    """
+    return {
+        "$and": [
+            {field_name: {"$exists": True}},
+            {field_name: None},
+        ]
+    }
+
+
 @app.command("diff-collections")
 def diff_collections(
         mongo_uri_a: Annotated[str, typer.Option(
@@ -252,7 +270,17 @@ def diff_collections(
                 )
 
             # Check whether a document having the same identifier value exists in collection B.
-            document_b = collection_b.find_one({identifier_field_name_b: identifier_value_a})
+            #
+            # Note: If the identifier value from document A was `None`, we use a special filter
+            #       (when checking collection B) to disambiguate between documents in which the
+            #       identifier field contains `None` and documents in which the identifier field
+            #       does not exist at all. MongoDB does not distinguish between those two cases when
+            #       we use a basic filter like `{field_name: None}`.
+            #
+            filter_b: dict = {identifier_field_name_b: identifier_value_a}
+            if identifier_value_a is None:
+                filter_b = make_pymongo_filter_for_field_having_value_null(identifier_field_name_b)
+            document_b = collection_b.find_one(filter=filter_b)
 
             # If such a document exists in collection B, compare it to the one from collection A.
             if document_b is not None:

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -70,12 +70,14 @@ class Result:
 
 class Comparator():
     @staticmethod
-    def compare_documents(document_a: dict, document_b: dict) -> bool:
+    def compare_documents(document_a: dict, document_b: dict, ignore_oid: bool = False) -> bool:
         r"""
-        Returns `True` if the documents have the same fields and values as one another; otherwise `False`.
+        Returns `True` if the documents have the same fields and values as one another;
+        otherwise `False`. Considers the `_id` field unless you opt out via `ignore_oid`.
         """
 
-        differences_generator = dictdiffer.diff(document_a, document_b)
+        fields_to_ignore = {"_id"} if ignore_oid else set()
+        differences_generator = dictdiffer.diff(document_a, document_b, ignore=fields_to_ignore)
         differences: list[tuple] = list(differences_generator)
         return len(differences) == 0
 
@@ -85,22 +87,29 @@ class Comparator():
         document_b: dict,
         label_a: str,
         label_b: str,
+        ignore_oid: bool = False,
     ) -> Iterator[str]:
         r"""
-        Returns an iterator that yields the lines of a Git-like diff of the documents'
-        canonical JSON representations.
+        Returns an iterator that yields the lines of a Git-like diff of the documents' canonical
+        JSON representations. Considers the `_id` field unless you opt out via `ignore_oid`.
 
         Reference: https://pymongo.readthedocs.io/en/stable/api/bson/json_util.html
         """
 
+        candidate_a = document_a.copy()
+        candidate_b = document_b.copy()
+        if ignore_oid:
+            candidate_a.pop("_id", None)
+            candidate_b.pop("_id", None)
+
         a_json = json_util.dumps(
-            document_a,
+            candidate_a,
             json_options=json_util.CANONICAL_JSON_OPTIONS,
             indent=2,
             sort_keys=True,
         )
         b_json = json_util.dumps(
-            document_b,
+            candidate_b,
             json_options=json_util.CANONICAL_JSON_OPTIONS,
             indent=2,
             sort_keys=True,
@@ -164,7 +173,9 @@ def diff_collections(
             show_default=False,
             rich_help_panel="Collection B",
         )] = None,
-        include_id: Annotated[bool, typer.Option(
+        include_oid: Annotated[bool, typer.Option(
+            "--include-oid",
+            "--include-id",  # support this legacy flag (a misnomer) for backwards compatibility
             help="Includes the `_id` field when comparing documents.",
         )] = False,
 ) -> None:
@@ -208,10 +219,6 @@ def diff_collections(
             collection = database[collection_name]
             collections.append(collection)
 
-    # Define a MongoDB query projection based upon whether the user wants us to consider the `_id`
-    # field when comparing documents or not.
-    projection = {"_id": 1 if include_id else  0}
-
     # Make more intuitive aliases for the collections.
     collection_a = collections[0]
     collection_b = collections[1]
@@ -232,7 +239,7 @@ def diff_collections(
         #
         task_a = progress.add_task("Comparing collections, using collection A as reference",
                                    total=num_documents_in_collection_a)
-        for document_a in collection_a.find({}, projection):
+        for document_a in collection_a.find({}):
 
             # Get the identifier value from the document from collection A.
             if identifier_field_name_a in document_a:
@@ -244,7 +251,7 @@ def diff_collections(
                 )
 
             # Check whether a document having the same identifier value exists in collection B.
-            document_b = collection_b.find_one({identifier_field_name_b: identifier_value_a}, projection)
+            document_b = collection_b.find_one({identifier_field_name_b: identifier_value_a})
 
             # If such a document exists in collection B, compare it to the one from collection A.
             if document_b is not None:
@@ -252,6 +259,7 @@ def diff_collections(
                 are_the_same = comparator.compare_documents(
                     document_a=document_a,
                     document_b=document_b,
+                    ignore_oid=not include_oid,
                 )
 
                 if not are_the_same:
@@ -265,6 +273,7 @@ def diff_collections(
                         document_b=document_b,
                         label_a=f"Collection A: {identifier_field_name_a}={identifier_value_a!r}",
                         label_b=f"Collection B: {identifier_field_name_b}={identifier_value_b!r}",
+                        ignore_oid=not include_oid,
                     )
                     for line in diff_lines:
                         if line.startswith("+"):


### PR DESCRIPTION
On this branch, I updated `mongo-diff` so that, when it encounters a pair of documents that differs across the two collections, it displays a color, Git-like diff of the JSON representations of the two documents.

```diff
--- Collection A: id='some.id.123'
+++ Collection B: id='some.id.123'
@@ -21,7 +21,7 @@
   "urls": [
     "https://www.example.com"
   ],
-  "title": "This is the old title",
+  "title": "This is the new title",
   "aliases": [
     "Nickname"
   ],
```

Currently (on this branch), this functionality is forced upon the user—it's not optional. Also, it's embedded within the normally-outputted single-line deltas, which I do not think is optimal for consumption. I will think about what to do regarding those aspects of this feature (e.g. add a CLI option, output the diffs _instead_ of the normally-outputted single-line deltas)—TBD.

Fixes #2 

While editing the Python module, I also fixed some type hints that didn't account for the possibility of the value being `None` (i.e. I changed `str` to `Optional[str]`). I also did some refactoring and added doctests.