### PR TITLE
Extract core functionality into functions to facilitate use of `mongo-diff` as library

### DIFF
--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -1,4 +1,5 @@
 from difflib import unified_diff
+from types import SimpleNamespace
 from typing import Any, Iterator, Optional
 
 import dictdiffer
@@ -18,10 +19,6 @@ app = typer.Typer(
     help="Compare two MongoDB collections.",
     add_completion=False,  # hides the shell completion options from `--help` output
 )
-
-# Instantiate a Rich console for fancy console output.
-# Reference: https://rich.readthedocs.io/en/stable/console.html
-console = Console()
 
 
 class Result:
@@ -121,9 +118,18 @@ class Result:
 class Comparator():
     """Compares MongoDB collections with one another."""
 
-    def __init__(self, console: Console) -> None:
-        """Initializes the comparator with the console on which you want progress to be displayed."""
-        self.console = console
+    def __init__(self, console: Console | None) -> None:
+        """
+        Initializes the comparator with the Rich `Console` instance, if any, onto which you want the
+        comparator to print progress messages.
+        """
+
+        if isinstance(console, Console):
+            self.console = console
+        else:
+            # Use a placeholder class whose `print` method does nothing.
+            # Docs: https://docs.python.org/3/library/types.html#types.SimpleNamespace
+            self.console = SimpleNamespace(print=lambda *args, **kwargs: None)
 
     @staticmethod
     def compare_documents(document_a: dict, document_b: dict, ignore_oid: bool = False) -> bool:
@@ -269,7 +275,10 @@ class Comparator():
 
         # Set up the progress bar functionality.
         self.console.print()
-        with Progress(console=console) as progress:
+        with Progress(
+            console=None if not isinstance(self.console, Console) else self.console,
+            disable=not isinstance(self.console, Console),
+        ) as progress:
             # Compare the collections, using collection A as the reference.
             #
             # Note: In this stage, we get each document from collection A and check whether it exists in collection B.
@@ -477,6 +486,11 @@ def diff_collections(
 
     Those collections can reside in either a single database or two separate databases (even across servers).
     """
+
+    # Instantiate a Rich console for fancy console output.
+    # Reference: https://rich.readthedocs.io/en/stable/console.html
+    console = Console()
+
     # For any collection B-related options that were omitted, use the values that were specified for collection A.
     database_name_b = database_name_a if database_name_b is None else database_name_b
     collection_name_b = collection_name_a if collection_name_b is None else collection_name_b

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -470,7 +470,7 @@ def diff_collections(
         identifier_field_name_b: Annotated[Optional[str], typer.Option(
             help="Name of the field of each document in collection B "
                  "to use to identify a corresponding document in collection A "
-                 "(if different from that specified for collection A)."
+                 "(if different from that specified for collection A). "
                  "The values in this field must be unique within each collection.",
             show_default=False,
             rich_help_panel="Collection B",

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -118,7 +118,7 @@ class Result:
 class Comparator():
     """Compares MongoDB collections with one another."""
 
-    def __init__(self, console: Console | None) -> None:
+    def __init__(self, console: Console | None = None) -> None:
         """
         Initializes the comparator with the Rich `Console` instance, if any, onto which you want the
         comparator to print progress messages.

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -4,6 +4,7 @@ from typing import Iterator, Optional
 import dictdiffer
 import typer
 from typing_extensions import Annotated
+from pymongo.collection import Collection
 from pymongo import MongoClient, timeout
 from bson import json_util
 from rich.console import Console
@@ -70,6 +71,12 @@ class Result:
 
 
 class Comparator():
+    """Compares MongoDB collections with one another."""
+
+    def __init__(self, console: Console) -> None:
+        """Initializes the comparator with the console on which you want progress to be displayed."""
+        self.console = console
+
     @staticmethod
     def compare_documents(document_a: dict, document_b: dict, ignore_oid: bool = False) -> bool:
         r"""
@@ -180,6 +187,166 @@ class Comparator():
             lineterm="",
         )
         return diff_lines
+
+    def compare_collections(
+        self,
+        collection_a: Collection,
+        collection_b: Collection,
+        identifier_field_name_a: str,
+        identifier_field_name_b: str,
+        ignore_oid: bool,
+    ) -> Result:
+        """
+        Compares one MongoDB collection with another one.
+
+        Identifies documents that (based on their identifier field) exist in one collection and not
+        in the other collection. Also identifiers differences that exist between documents that
+        (based on their identifier field) exist in both collections, but do not match one another.
+
+        :param collection_a: One collection.
+        :param collection_b: The other collection.
+        :param identifier_field_name_a: The name of the field of each document in collection A to
+                                        use to identify a corresponding document in collection B.
+        :param identifier_field_name_b: The name of the field of each document in collection B to
+                                        use to identify a corresponding document in collection A.
+        :param ignore_oid: Whether to ignore the `_id` field when comparing documents.
+
+        :returns: A `Result` instance containing the result of the comparison.
+        """
+
+        # Initialize the report we will return.
+        num_documents_in_collection_a = collection_a.count_documents({})
+        num_documents_in_collection_b = collection_b.count_documents({})
+        report = Result(num_documents_in_collection_a, num_documents_in_collection_b)
+
+        # Set up the progress bar functionality.
+        self.console.print()
+        with Progress(console=console) as progress:
+            # Compare the collections, using collection A as the reference.
+            #
+            # Note: In this stage, we get each document from collection A and check whether it exists in collection B.
+            #       If it does, we compare the two documents and display any differences. If it doesn't, we display the
+            #       identifier value from collection A (i.e. the identifier value we failed to find in collection B).
+            #
+            task_a = progress.add_task("Comparing collections, using collection A as reference",
+                                    total=num_documents_in_collection_a)
+            for document_a in collection_a.find({}):
+
+                # Get the identifier value from the document from collection A.
+                if identifier_field_name_a in document_a:
+                    identifier_value_a = document_a[identifier_field_name_a]
+                else:
+                    raise ValueError(
+                        f"Document from collection A lacks identifier field: '{identifier_field_name_a}'. "
+                        f"Document: {document_a}"
+                    )
+
+                # Check whether a document having the same identifier value exists in collection B.
+                #
+                # Note: If the identifier value from document A was `None`, we use a special filter
+                #       (when checking collection B) to disambiguate between documents in which the
+                #       identifier field contains `None` and documents in which the identifier field
+                #       does not exist at all. MongoDB does not distinguish between those two cases when
+                #       we use a basic filter like `{field_name: None}`.
+                #
+                filter_b: dict = {identifier_field_name_b: identifier_value_a}
+                if identifier_value_a is None:
+                    filter_b = make_pymongo_filter_for_field_having_value_null(identifier_field_name_b)
+                document_b = collection_b.find_one(filter=filter_b)
+
+                # If such a document exists in collection B, compare it to the one from collection A.
+                if document_b is not None:
+                    are_the_same = self.compare_documents(
+                        document_a=document_a,
+                        document_b=document_b,
+                        ignore_oid=ignore_oid,
+                    )
+
+                    if not are_the_same:
+                        report.num_documents_that_differ_across_collections += 1
+                        identifier_value_b = document_b[identifier_field_name_b]
+                        self.console.print("Document differs between collections:")
+
+                        # Display a colorized diff of the two documents' canonical JSON representations.
+                        diff_lines = self.generate_diff(
+                            document_a=document_a,
+                            document_b=document_b,
+                            label_a=f"Collection A: {identifier_field_name_a}={identifier_value_a!r}",
+                            label_b=f"Collection B: {identifier_field_name_b}={identifier_value_b!r}",
+                            ignore_oid=ignore_oid,
+                        )
+                        for line in diff_lines:
+                            if line.startswith("+"):
+                                self.console.print(line, style="green", highlight=False, markup=False)
+                            elif line.startswith("-"):
+                                self.console.print(line, style="red", highlight=False, markup=False)
+                            else:
+                                self.console.print(line, highlight=False, markup=False)
+                        self.console.print()
+
+                else:
+                    report.num_documents_in_collection_a_only += 1
+                    self.console.print(
+                        f"Document exists in collection A only: "
+                        f"[red]{escape(identifier_field_name_a)}={escape(repr(identifier_value_a))}[/red]",
+                        highlight=False,
+                    )
+
+                # Advance the progress bar by 1.
+                progress.update(task_a, advance=1)
+
+            # Compare the collections, using collection B as the reference.
+            #
+            # Note: In this stage, we get each document from collection B and check whether it exists in collection A.
+            #       If it does, we do nothing; since we will have already checked whether the two documents match during
+            #       the previous stage (note that this is done under the assumption that the contents of the collections
+            #       do not change while this script is running). If it doesn't exist in collection A, we display the
+            #       identifier value from collection B (i.e. the identifier value we failed to find in collection A).
+            #
+            task_b = progress.add_task("Comparing collections, using collection B as reference",
+                                    total=num_documents_in_collection_b)
+            for document_b in collection_b.find():
+
+                # Get the identifier value from the document from collection B.
+                if identifier_field_name_b in document_b:
+                    identifier_value_b = document_b[identifier_field_name_b]
+                else:
+                    raise ValueError(
+                        f"Document from collection B lacks identifier field: {identifier_field_name_b}. "
+                        f"Document: {document_b}"
+                    )
+
+                # Check whether a document having the same identifier value exists in collection A.
+                #
+                # Note: If the identifier value from document B was `None`, we use a special filter
+                #       (when checking collection A) to disambiguate between documents in which the
+                #       identifier field contains `None` and documents in which the identifier field
+                #       does not exist at all. MongoDB does not distinguish between those two cases when
+                #       we use a basic filter like `{field_name: None}`.
+                #
+                filter_a: dict = {identifier_field_name_a: identifier_value_b}
+                if identifier_value_b is None:
+                    filter_a = make_pymongo_filter_for_field_having_value_null(identifier_field_name_a)
+                document_a = collection_a.find_one(filter=filter_a)
+
+                # If such a document exists in collection B, compare it to the one from collection A.
+                if document_a is None:
+                    report.num_documents_in_collection_b_only += 1
+                    self.console.print(
+                        f"Document exists in collection B only: "
+                        f"[green]{escape(identifier_field_name_b)}={escape(repr(identifier_value_b))}[/green]",
+                        highlight=False,
+                    )
+
+                # Advance the progress bar by 1.
+                progress.update(task_b, advance=1)
+
+        # Display a table summarizing the result.
+        self.console.print()
+        self.console.print(report.get_summary_table())
+        self.console.print()
+
+        return report
 
 
 def make_pymongo_filter_for_field_having_value_null(field_name: str) -> dict:
@@ -302,138 +469,15 @@ def diff_collections(
     collection_a = collections[0]
     collection_b = collections[1]
 
-    # Initialize the report we will display later.
-    num_documents_in_collection_a = collection_a.count_documents({})
-    num_documents_in_collection_b = collection_b.count_documents({})
-    report = Result(num_documents_in_collection_a, num_documents_in_collection_b)
-
-    # Set up the progress bar functionality.
-    console.print()
-    with Progress(console=console) as progress:
-        # Compare the collections, using collection A as the reference.
-        #
-        # Note: In this stage, we get each document from collection A and check whether it exists in collection B.
-        #       If it does, we compare the two documents and display any differences. If it doesn't, we display the
-        #       identifier value from collection A (i.e. the identifier value we failed to find in collection B).
-        #
-        task_a = progress.add_task("Comparing collections, using collection A as reference",
-                                   total=num_documents_in_collection_a)
-        for document_a in collection_a.find({}):
-
-            # Get the identifier value from the document from collection A.
-            if identifier_field_name_a in document_a:
-                identifier_value_a = document_a[identifier_field_name_a]
-            else:
-                raise ValueError(
-                    f"Document from collection A lacks identifier field: '{identifier_field_name_a}'. "
-                    f"Document: {document_a}"
-                )
-
-            # Check whether a document having the same identifier value exists in collection B.
-            #
-            # Note: If the identifier value from document A was `None`, we use a special filter
-            #       (when checking collection B) to disambiguate between documents in which the
-            #       identifier field contains `None` and documents in which the identifier field
-            #       does not exist at all. MongoDB does not distinguish between those two cases when
-            #       we use a basic filter like `{field_name: None}`.
-            #
-            filter_b: dict = {identifier_field_name_b: identifier_value_a}
-            if identifier_value_a is None:
-                filter_b = make_pymongo_filter_for_field_having_value_null(identifier_field_name_b)
-            document_b = collection_b.find_one(filter=filter_b)
-
-            # If such a document exists in collection B, compare it to the one from collection A.
-            if document_b is not None:
-                comparator = Comparator()
-                are_the_same = comparator.compare_documents(
-                    document_a=document_a,
-                    document_b=document_b,
-                    ignore_oid=not include_oid,
-                )
-
-                if not are_the_same:
-                    report.num_documents_that_differ_across_collections += 1
-                    identifier_value_b = document_b[identifier_field_name_b]
-                    console.print("Document differs between collections:")
-
-                    # Display a colorized diff of the two documents' canonical JSON representations.
-                    diff_lines = comparator.generate_diff(
-                        document_a=document_a,
-                        document_b=document_b,
-                        label_a=f"Collection A: {identifier_field_name_a}={identifier_value_a!r}",
-                        label_b=f"Collection B: {identifier_field_name_b}={identifier_value_b!r}",
-                        ignore_oid=not include_oid,
-                    )
-                    for line in diff_lines:
-                        if line.startswith("+"):
-                            console.print(line, style="green", highlight=False, markup=False)
-                        elif line.startswith("-"):
-                            console.print(line, style="red", highlight=False, markup=False)
-                        else:
-                            console.print(line, highlight=False, markup=False)
-                    console.print()
-
-            else:
-                report.num_documents_in_collection_a_only += 1
-                console.print(
-                    f"Document exists in collection A only: "
-                    f"[red]{escape(identifier_field_name_a)}={escape(repr(identifier_value_a))}[/red]",
-                    highlight=False,
-                )
-
-            # Advance the progress bar by 1.
-            progress.update(task_a, advance=1)
-
-        # Compare the collections, using collection B as the reference.
-        #
-        # Note: In this stage, we get each document from collection B and check whether it exists in collection A.
-        #       If it does, we do nothing; since we will have already checked whether the two documents match during
-        #       the previous stage (note that this is done under the assumption that the contents of the collections
-        #       do not change while this script is running). If it doesn't exist in collection A, we display the
-        #       identifier value from collection B (i.e. the identifier value we failed to find in collection A).
-        #
-        task_b = progress.add_task("Comparing collections, using collection B as reference",
-                                   total=num_documents_in_collection_b)
-        for document_b in collection_b.find():
-
-            # Get the identifier value from the document from collection B.
-            if identifier_field_name_b in document_b:
-                identifier_value_b = document_b[identifier_field_name_b]
-            else:
-                raise ValueError(
-                    f"Document from collection B lacks identifier field: {identifier_field_name_b}. "
-                    f"Document: {document_b}"
-                )
-
-            # Check whether a document having the same identifier value exists in collection A.
-            #
-            # Note: If the identifier value from document B was `None`, we use a special filter
-            #       (when checking collection A) to disambiguate between documents in which the
-            #       identifier field contains `None` and documents in which the identifier field
-            #       does not exist at all. MongoDB does not distinguish between those two cases when
-            #       we use a basic filter like `{field_name: None}`.
-            #
-            filter_a: dict = {identifier_field_name_a: identifier_value_b}
-            if identifier_value_b is None:
-                filter_a = make_pymongo_filter_for_field_having_value_null(identifier_field_name_a)
-            document_a = collection_a.find_one(filter=filter_a)
-
-            # If such a document exists in collection B, compare it to the one from collection A.
-            if document_a is None:
-                report.num_documents_in_collection_b_only += 1
-                console.print(
-                    f"Document exists in collection B only: "
-                    f"[green]{escape(identifier_field_name_b)}={escape(repr(identifier_value_b))}[/green]",
-                    highlight=False,
-                )
-
-            # Advance the progress bar by 1.
-            progress.update(task_b, advance=1)
-
-    # Display a table summarizing the result.
-    console.print()
-    console.print(report.get_summary_table())
-    console.print()
+    # Compare the collections with one another.
+    comparator = Comparator(console=console)
+    _ = comparator.compare_collections(
+        collection_a=collection_a,
+        collection_b=collection_b,
+        identifier_field_name_a=identifier_field_name_a,
+        identifier_field_name_b=identifier_field_name_b,
+        ignore_oid=not include_oid,
+    )
 
 
 if __name__ == "__main__":

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -31,7 +31,7 @@ class Result:
         self.identifiers_of_documents_in_collection_a_only: list[Any] = []
         self.identifiers_of_documents_in_collection_b_only: list[Any] = []
         self.identifiers_of_differing_documents: list[Any] = []
-        self.diff_lines_of_differing_documents: dict[str, list[str]] = {}
+        self.diff_lines_of_differing_documents: dict[Any, list[str]] = {}
     
     @property
     def num_documents_in_collection_a_only(self) -> int:
@@ -254,7 +254,7 @@ class Comparator():
         Compares one MongoDB collection with another one.
 
         Identifies documents that (based on their identifier field) exist in one collection and not
-        in the other collection. Also identifiers differences that exist between documents that
+        in the other collection. Also identifies differences that exist between documents that
         (based on their identifier field) exist in both collections, but do not match one another.
 
         :param collection_a: One collection.

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -1,5 +1,5 @@
 from difflib import unified_diff
-from typing import Iterator, Optional
+from typing import Any, Iterator, Optional
 
 import dictdiffer
 import typer
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.markup import escape
 from rich.table import Table, Column
 from rich.progress import Progress
+from rich.text import Text
 from rich import box
 
 app = typer.Typer(
@@ -28,16 +29,63 @@ class Result:
 
     def __init__(self, num_documents_in_collection_a: int, num_documents_in_collection_b: int) -> None:
         r"""Initializes the result."""
-        self.num_documents_in_collection_a = num_documents_in_collection_a
-        self.num_documents_in_collection_b = num_documents_in_collection_b
-        self.num_documents_in_collection_a_only = 0
-        self.num_documents_in_collection_b_only = 0
-        self.num_documents_that_differ_across_collections = 0
+        self.num_documents_in_collection_a: int = num_documents_in_collection_a
+        self.num_documents_in_collection_b: int = num_documents_in_collection_b
+        self.identifiers_of_documents_in_collection_a_only: list[Any] = []
+        self.identifiers_of_documents_in_collection_b_only: list[Any] = []
+        self.identifiers_of_differing_documents: list[Any] = []
+        self.diff_lines_of_differing_documents: dict[str, list[str]] = {}
+    
+    @property
+    def num_documents_in_collection_a_only(self) -> int:
+        return len(self.identifiers_of_documents_in_collection_a_only)
+    
+    @property
+    def num_documents_in_collection_b_only(self) -> int:
+        return len(self.identifiers_of_documents_in_collection_b_only)
+    
+    @property
+    def num_differing_documents(self) -> int:
+        return len(self.identifiers_of_differing_documents)
 
     @staticmethod
     def colorize_if(raw_string: str, condition: bool, color: str) -> str:
         r"""Surrounds the raw string with Rich color tags if the condition is true."""
         return f"[{color}]{raw_string}[/{color}]" if condition else raw_string
+
+    @staticmethod
+    def colorize_diff_lines(diff_lines: list[str]) -> list[Text]:
+        r"""
+        Returns a list of Rich `Text` instances corresponding to the diff lines, with colorization.
+        The caller can then display those `Text` instances via plain `console.print()` calls.
+
+        References:
+        - https://rich.readthedocs.io/en/latest/text.html
+        - https://rich.readthedocs.io/en/latest/protocol.html
+        """
+
+        colorized_lines: list[Text] = []
+        for line in diff_lines:
+            if line.startswith("-"):
+                colorized_lines.append(Text(line, style="red"))
+            elif line.startswith("+"):
+                colorized_lines.append(Text(line, style="green"))
+            else:
+                colorized_lines.append(Text(line))
+        return colorized_lines
+
+    def get_all_colorized_diff_lines(self) -> list[Text]:
+        r"""
+        Returns a list of Rich `Text` instances that, together, represent the diffs of all differing
+        documents, with colorization.
+        """
+
+        colorized_lines: list[Text] = []
+        for diff_lines in self.diff_lines_of_differing_documents.values():
+            colorized_lines_part = self.colorize_diff_lines(diff_lines=diff_lines)
+            colorized_lines.extend(colorized_lines_part)
+            colorized_lines.append(Text(""))
+        return colorized_lines
 
     def get_summary_table(self, title: Optional[str] = "Result") -> Table:
         r"""
@@ -64,8 +112,8 @@ class Result:
                                        color="red"))
         table.add_section()
         table.add_row("Documents that differ between collections",
-                      self.colorize_if(raw_string=str(self.num_documents_that_differ_across_collections),
-                                       condition=self.num_documents_that_differ_across_collections > 0,
+                      self.colorize_if(raw_string=str(self.num_differing_documents),
+                                       condition=self.num_differing_documents > 0,
                                        color="red"))
         return table
 
@@ -263,29 +311,31 @@ class Comparator():
                     )
 
                     if not are_the_same:
-                        report.num_documents_that_differ_across_collections += 1
                         identifier_value_b = document_b[identifier_field_name_b]
                         self.console.print("Document differs between collections:")
 
-                        # Display a colorized diff of the two documents' canonical JSON representations.
-                        diff_lines = self.generate_diff(
+                        # Generate a diff of the two documents' canonical JSON representations.
+                        diff_lines: Iterator[str] = self.generate_diff(
                             document_a=document_a,
                             document_b=document_b,
                             label_a=f"Collection A: {identifier_field_name_a}={identifier_value_a!r}",
                             label_b=f"Collection B: {identifier_field_name_b}={identifier_value_b!r}",
                             ignore_oid=ignore_oid,
                         )
-                        for line in diff_lines:
-                            if line.startswith("+"):
-                                self.console.print(line, style="green", highlight=False, markup=False)
-                            elif line.startswith("-"):
-                                self.console.print(line, style="red", highlight=False, markup=False)
-                            else:
-                                self.console.print(line, highlight=False, markup=False)
+                        report.identifiers_of_differing_documents.append(identifier_value_a)
+                        report.diff_lines_of_differing_documents[identifier_value_a] = list(diff_lines)
+
+                        # Display a colorized version of the diff.
+                        # Note: We reference our list, since we will have "exhausted" the `diff_lines` iterator.
+                        colorized_lines = report.colorize_diff_lines(
+                            diff_lines=report.diff_lines_of_differing_documents[identifier_value_a],
+                        )
+                        for line in colorized_lines:
+                            self.console.print(line)
                         self.console.print()
 
                 else:
-                    report.num_documents_in_collection_a_only += 1
+                    report.identifiers_of_documents_in_collection_a_only.append(identifier_value_a)
                     self.console.print(
                         f"Document exists in collection A only: "
                         f"[red]{escape(identifier_field_name_a)}={escape(repr(identifier_value_a))}[/red]",
@@ -331,7 +381,7 @@ class Comparator():
 
                 # If such a document exists in collection B, compare it to the one from collection A.
                 if document_a is None:
-                    report.num_documents_in_collection_b_only += 1
+                    report.identifiers_of_documents_in_collection_b_only.append(identifier_value_b)
                     self.console.print(
                         f"Document exists in collection B only: "
                         f"[green]{escape(identifier_field_name_b)}={escape(repr(identifier_value_b))}[/green]",
@@ -340,11 +390,6 @@ class Comparator():
 
                 # Advance the progress bar by 1.
                 progress.update(task_b, advance=1)
-
-        # Display a table summarizing the result.
-        self.console.print()
-        self.console.print(report.get_summary_table())
-        self.console.print()
 
         return report
 
@@ -390,7 +435,8 @@ def diff_collections(
         )],
         identifier_field_name_a: Annotated[str, typer.Option(
             help="Name of the field of each document in collection A "
-                 "to use to identify a corresponding document in collection B.",
+                 "to use to identify a corresponding document in collection B. "
+                 "The values in this field must be unique within each collection.",
             rich_help_panel="Collection A",
         )] = "id",
         mongo_uri_b: Annotated[Optional[str], typer.Option(
@@ -415,7 +461,8 @@ def diff_collections(
         identifier_field_name_b: Annotated[Optional[str], typer.Option(
             help="Name of the field of each document in collection B "
                  "to use to identify a corresponding document in collection A "
-                 "(if different from that specified for collection A).",
+                 "(if different from that specified for collection A)."
+                 "The values in this field must be unique within each collection.",
             show_default=False,
             rich_help_panel="Collection B",
         )] = None,
@@ -471,7 +518,7 @@ def diff_collections(
 
     # Compare the collections with one another.
     comparator = Comparator(console=console)
-    _ = comparator.compare_collections(
+    report = comparator.compare_collections(
         collection_a=collection_a,
         collection_b=collection_b,
         identifier_field_name_a=identifier_field_name_a,
@@ -479,6 +526,10 @@ def diff_collections(
         ignore_oid=not include_oid,
     )
 
+    # Display a table summarizing the result.
+    console.print()
+    console.print(report.get_summary_table())
+    console.print()
 
 if __name__ == "__main__":
     app()

--- a/mongo_diff/mongo_diff.py
+++ b/mongo_diff/mongo_diff.py
@@ -289,6 +289,9 @@ class Comparator():
                                     total=num_documents_in_collection_a)
             for document_a in collection_a.find({}):
 
+                # Get the `_id` value from the document from collection A.
+                oid_value_a = document_a["_id"]
+
                 # Get the identifier value from the document from collection A.
                 if identifier_field_name_a in document_a:
                     identifier_value_a = document_a[identifier_field_name_a]
@@ -331,14 +334,14 @@ class Comparator():
                             label_b=f"Collection B: {identifier_field_name_b}={identifier_value_b!r}",
                             ignore_oid=ignore_oid,
                         )
+                        diff_lines_list = list(diff_lines)  # exhausts the iterator
+
+                        # Update the report.
                         report.identifiers_of_differing_documents.append(identifier_value_a)
-                        report.diff_lines_of_differing_documents[identifier_value_a] = list(diff_lines)
+                        report.diff_lines_of_differing_documents[oid_value_a] = diff_lines_list
 
                         # Display a colorized version of the diff.
-                        # Note: We reference our list, since we will have "exhausted" the `diff_lines` iterator.
-                        colorized_lines = report.colorize_diff_lines(
-                            diff_lines=report.diff_lines_of_differing_documents[identifier_value_a],
-                        )
+                        colorized_lines = report.colorize_diff_lines(diff_lines=diff_lines_list)
                         for line in colorized_lines:
                             self.console.print(line)
                         self.console.print()


### PR DESCRIPTION
On this branch, I made some changes in an attempt to make it easier for people to use `mongo-diff` as a library rather than only as a CLI application.

Specifically, I extracted its core functionality into functions, made it so the console output during comparison could be silenced, and made the details of the diff result be available via a returned `Result` instance.